### PR TITLE
Bump babel polyfill packages to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
         "clean": "rimraf lib",
         "test": "npm run lint && npm run cover",
         "test:prod": "cross-env BABEL_ENV=production npm run test",
-        "test:only": "mocha --require babel-core/register --require babel-polyfill --recursive --timeout 5000",
+        "test:only": "mocha --require babel-core/register --require @babel/polyfill --recursive --timeout 5000",
         "test:watch": "npm test -- --watch",
         "test:examples": "node examples/",
-        "cover": "istanbul cover _mocha -- --require babel-core/register --require babel-polyfill --recursive --timeout 5000",
+        "cover": "istanbul cover _mocha -- --require babel-core/register --require @babel/polyfill --recursive --timeout 5000",
         "lint": "eslint src test",
         "build": "cross-env BABEL_ENV=production babel src --out-dir lib",
         "build:docs": "npx jsdoc-to-markdown --template README.hbs --files ./src/index.js > README.md",
@@ -59,13 +59,13 @@
         "rimraf": "^2.6.2"
     },
     "dependencies": {
+        "@babel/polyfill": "^7.7.0",
         "babel-cli": "^6.26.0",
         "babel-eslint": "^8.2.6",
         "babel-plugin-add-module-exports": "^0.2.1",
-        "babel-polyfill": "^6.26.0",
         "babel-preset-env": "^1.6.1",
         "babel-preset-minify": "^0.3.0",
-        "idempotent-babel-polyfill": "^7.0.0",
+        "idempotent-babel-polyfill": "^7.4.4",
         "ipfs-mini": "^1.1.2",
         "web3": "^1.0.0-beta.36"
     }


### PR DESCRIPTION
#4 
- [x] All tests pass with same coverage as before

Some improvements that can be done here as well would be to deprecate these plugin packages and move them to the new babel path though don't want to break too much downstream